### PR TITLE
Allow animations to be disabled on a per-animation basis or globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragments-js",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "Fragments is an ultra-fast templating and data-binding library for front-end JavaScript applications.",
   "keywords": [
     "templates",

--- a/src/animated-binding.js
+++ b/src/animated-binding.js
@@ -81,9 +81,9 @@ Binding.extend(AnimatedBinding, {
     _super.init.call(this);
 
     if (this.animateExpression) {
-      this.animateObserver = new this.Observer(this.animateExpression, function(value) {
+      this.animateObserver = new this.watch(this.animateExpression, function(value) {
         this.animateObject = value;
-      }, this);
+      });
     }
   },
 

--- a/src/animated-binding.js
+++ b/src/animated-binding.js
@@ -135,13 +135,24 @@ Binding.extend(AnimatedBinding, {
     var animateObject, className, classAnimateName, classWillName, whenDone,
         methodAnimateName, methodWillName, methodDidName, dir, _this = this;
 
+    if (this.fragments.disableAnimations) {
+      return callback.call(_this);
+    }
+
     if (this.animateObject && typeof this.animateObject === 'object') {
       animateObject = this.animateObject;
       animateObject.fragments = this.fragments;
     } else if (this.animateClassName) {
       className = this.animateClassName;
+    } else if (this.animateObject === false) {
+      return callback.call(_this);
     } else if (typeof this.animateObject === 'string') {
-      className = this.animateObject;
+      if (this.animateObject[0] === '.') {
+        className = this.animateObject.slice(1);
+      } else if (this.animateObject) {
+        animateObject = fragments.getAnimation(this.animateObject);
+        if (typeof animateObject === 'function') animateObject = new animateObject(this);
+      }
     }
 
     classAnimateName = 'animate-' + direction;

--- a/src/binding.js
+++ b/src/binding.js
@@ -50,7 +50,7 @@ ElementController.extend(Binding, {
 
     if (this.expression && this.updated !== Binding.prototype.updated) {
       // An observer to observe value changes to the expression within a context
-      this.observer = this.watch(this.expression, this.updated, this);
+      this.observer = this.watch(this.expression, this.updated);
     }
     this.created();
   },


### PR DESCRIPTION
The `animate` attribute can now be set to an expression that returns
`false` to disable the animation. And setting
`fragments.disableAnimations = true` will disable all animations.