### PR TITLE
fix type error for this._listeners.enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragments-js",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Fragments is an ultra-fast templating and data-binding library for front-end JavaScript applications.",
   "keywords": [
     "templates",

--- a/src/element-controller.js
+++ b/src/element-controller.js
@@ -14,11 +14,11 @@ function ElementController(observations) {
 
 ObservableHash.extend(ElementController, {
   get listenersEnabled() {
-    return this._listeners.enabled;
+    return this._listeners && this._listeners.enabled;
   },
 
   set listenersEnabled(value) {
-    if (this.enabled === value) return;
+    if (!this._listeners || this.enabled === value) return;
     this._listeners.enabled = value;
 
     // Bind/unbind the observers for this hash


### PR DESCRIPTION
It's possible for `this._listeners` to be `undefined` when this code is run, so I added a few extra checks